### PR TITLE
Mentioned support for CHC Pro Volcano hotend from Trianglelab README.md

### DIFF
--- a/V0/Rapid_Burner/README.md
+++ b/V0/Rapid_Burner/README.md
@@ -77,6 +77,7 @@ You can also continue to use the [Rapid Burner v4](https://github.com/chirpy2605
 - Goliath Air
 - Goliath Water
 - E3D V6 Groove Mount Volcano
+- CHC Pro Volcano 115W (Use V6 Groove Mount)
 
 ### Extruder support:
 


### PR DESCRIPTION
I was almost done implementing mount for Trianglelab's CHC Pro Volcano for my [Baton CoreXY](https://cad.onshape.com/documents/4202b460e8193c14455766da/w/db5d2b8ba5bf8abcbf6fb982/e/96b0b75cd1994881805cc75a) which is around 70mm with V6 groove, than saw your version 8 update for V6 groove. 

I took me a while to figure it out that Rapid Burner is the way to go for Volcano hotends, therefore updating the Readme that should helps anyone looking this hotend.

