### PR TITLE
Mention Lowboi Mk4 as a supported extruder

### DIFF
--- a/V0/Dragon_Burner/README.md
+++ b/V0/Dragon_Burner/README.md
@@ -109,6 +109,7 @@ You can also continue to use the [Dragon Burner v4](https://github.com/chirpy260
 - Galileo v2 Standalone (G2SA) with specific mounts for Sherpa Mini and Orbiter v2 mount hole configurations
 - Wristwatch BMG and G2 use the Orbiter v2 hotend mounts
 - Papilio Lite (Paplite) extruder (use Sherpa Mini mount)
+- [Lowboi Mk4](https://github.com/Shaunuss/Lowboi-Mk4) (use Sherpa Mini or Orbiter V2 mount)
 
 **NOTE**: Hotend mounts for the Sherpa Mini spacing, the G2SA, the Wristwatch BMG and G2, together with the LGX Lite are at the top-level of the STL directory. Extruders with different mount patterns are in the extruder specific sub-directories.
 

--- a/V0/Rapid_Burner/README.md
+++ b/V0/Rapid_Burner/README.md
@@ -88,6 +88,7 @@ You can also continue to use the [Rapid Burner v4](https://github.com/chirpy2605
 - Double Folded Ascender (not for the Goliath Hotend)
 - [RoundTrip](https://github.com/waytotheweb/voron/tree/main/general/RoundTrip) (Gears from the LGX Lite, TBG Lite, Orbiter v1.5, Orbiter v2)
 - Galileo v2 Standalone (G2SA) with specific mounts for Sherpa Mini and Orbiter v2 mount hole configurations
+- [Lowboi Mk4](https://github.com/Shaunuss/Lowboi-Mk4) (use Sherpa Mini or Orbiter V2 mount)
 
 ### Fan support:
 


### PR DESCRIPTION
Lowboi MK4 adds a unique value to the lineup with low mass and possibly the highest torque in the lineup (feel free to correct me). It also uses a larger drive wheel diameter and a smooth idler bearing which should help towards extrusion consistency over Double folded ascender which is the other extruder in the lineup.

No additional files or maintenance required.

![image](https://github.com/user-attachments/assets/228d2074-768c-495d-b6b7-f2497fa5bdbe)
